### PR TITLE
feat: save QR code locally for terminal display compatibility

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -15,6 +15,16 @@ def strToClass(class_name: str, module: str="__main__"):
     return getattr(sys.modules[module], class_name)
 
 def showImage(img, show_in_terminal=False, ensure_unicode=False):
+    os.makedirs("./images", exist_ok=True)
+    filepath = os.path.join("./images", "qr.temp.jpg")
+
+    try:
+        image_obj = Image.open(io.BytesIO(img))
+        image_obj.save(filepath, format="JPEG")
+    except Exception as e:
+        print(f"Failed to save QR code: {e}")
+        pass
+        
     if show_in_terminal:
         if ensure_unicode:
             terminalShowImage_unicode(img)


### PR DESCRIPTION
Link to issue: #133 

Always save the generated QR code image to ./images/qr.temp.jpg to handle cases where terminal display is not supported.

This ensures compatibility across different environments and enables future alternative processing methods.

<img width="1486" height="864" alt="image" src="https://github.com/user-attachments/assets/915e3ace-34c1-4c91-8622-063a815fbcbb" />
